### PR TITLE
fix the bugs when netsed is used in docker container. 

### DIFF
--- a/netsed.c
+++ b/netsed.c
@@ -391,6 +391,8 @@ char hex[]="0123456789ABCDEF";
 void shrink_to_binary(struct rule_s* r) {
   int i;
 
+  r->ts = 0;
+  r->fs = 0;
   r->from=malloc(strlen(r->forig));
   r->to=malloc(strlen(r->torig));
   if ((!r->from) || (!r->to)) error("shrink_to_binary: unable to malloc() buffers");


### PR DESCRIPTION
set the initial values of #from buffer and #to buffer to 0.
